### PR TITLE
filter out non serializable key/values before minifying

### DIFF
--- a/ejson.minimax.js
+++ b/ejson.minimax.js
@@ -228,8 +228,13 @@
   };
 
   MiniMax.prototype.stringify = function(plainObject) {
+    // Keep only serializable (with EJSON) keys
+    // You could instead only filter out functions, but
+    // this is probably more future proof if EJSON get new capabilities
+    // or the user use a custom EJSON
+    var serializableObject = EJSON.parse(EJSON.stringify(plainObject));
     // Compress the object
-    var minifiedObject = this.minify(plainObject);
+    var minifiedObject = this.minify(serializableObject);
     // Convert it into string
     return EJSON.stringify(minifiedObject);
   };

--- a/ejson.minimax.tests.js
+++ b/ejson.minimax.tests.js
@@ -13,6 +13,7 @@ var speedTest = function(name, num, func) {
   console.log(name + ((Date.now() - startTime))/num + ' ms');
 }
 
+
 Tinytest.add('Minify Maxify - test date', function(test) {
   var newTimeStamp = 1409300873188;
   var newDate = new Date(newTimeStamp);
@@ -279,6 +280,13 @@ Tinytest.add('Minify Maxify - test', function(test) {
   });
 
 
+});
+
+
+Tinytest.add('Minify Maxify - Objects with functions', function(test){
+  var obj = {a:1,b:function(){return "foo";},c:function(){return "bar";}};
+  var result = MiniMax.parse(MiniMax.stringify(obj));
+  test.isTrue(_.isEqual({a:1},result, "keys containing functions should be dropped"));
 });
 
 


### PR DESCRIPTION
Actually there is a bug when objects to stringify have methods.
With {a:1, b:function(){return "foo"}} object, minify produce a keywords array with the whole function source stored as a keyword. However, EJSON.stringify will replace the function stored as a keyword with null.
When doing maxify, the unintended "null" value with cause the maxification to produce garbage.
Since functions are not serializable by EJSON, i have taken the liberty to do a EJSON.stringify(EJSON.parse()) in the Minimax.stringify function.
I think it's more future proof than only filtering out functions, since EJSON is an external dependency that can change or be customized by the user.